### PR TITLE
use __system_property_get to replace property_get

### DIFF
--- a/boot_control_avb.c
+++ b/boot_control_avb.c
@@ -55,7 +55,11 @@ static unsigned int module_getNumberSlots(boot_control_module_t* module) {
 static unsigned int module_getCurrentSlot(boot_control_module_t* module) {
   char propbuf[PROPERTY_VALUE_MAX];
 
-  property_get("ro.boot.slot_suffix", propbuf, "");
+  if (__system_property_get("ro.boot.slot_suffix", propbuf) < 0) {
+    avb_errorv("Unable to read slot suffix in ro.boot.slot_suffix\n", NULL);
+    return 0;
+  }
+
   if (strcmp(propbuf, "_a") == 0) {
     return 0;
   } else if (strcmp(propbuf, "_b") == 0) {


### PR DESCRIPTION
property_get can not be linked in static lib in recovery

Tracked-On: OAM-84107

Signed-off-by: Xihua Chen <xihua.chen@intel.com>