### PR TITLE
Sync bootctrl with kernelflinger

### DIFF
--- a/boot_control_avb.c
+++ b/boot_control_avb.c
@@ -115,9 +115,9 @@ static int module_isSlotBootable(struct boot_control_module* module,
     return -EIO;
   }
 
-  is_bootable = (ab_data.slots[slot].priority > 0) &&
-                (ab_data.slots[slot].successful_boot ||
-                 (ab_data.slots[slot].tries_remaining > 0));
+  is_bootable = (ab_data.slot_info[slot].priority > 0) &&
+                (ab_data.slot_info[slot].successful_boot ||
+                 (ab_data.slot_info[slot].tries_remaining > 0));
 
   return is_bootable ? 1 : 0;
 }
@@ -135,7 +135,7 @@ static int module_isSlotMarkedSuccessful(struct boot_control_module* module,
     return -EIO;
   }
 
-  is_marked_successful = ab_data.slots[slot].successful_boot;
+  is_marked_successful = ab_data.slot_info[slot].successful_boot;
 
   return is_marked_successful ? 1 : 0;
 }

--- a/libavb_ab/avb_ab_flow.c
+++ b/libavb_ab/avb_ab_flow.c
@@ -26,24 +26,22 @@
 
 bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
   /* Ensure magic is correct. */
-  if (avb_safe_memcmp(src->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN) != 0) {
+  if (src->magic != BOOT_CTRL_MAGIC) {
     avb_error("Magic is incorrect.\n");
     return false;
   }
 
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_be32toh(dest->crc32);
-
   /* Ensure we don't attempt to access any fields if the major version
    * is not supported.
    */
-  if (dest->version_major > AVB_AB_MAJOR_VERSION) {
+  if (dest->version_major > BOOT_CTRL_VERSION) {
     avb_error("No support for given major version.\n");
     return false;
   }
 
   /* Bail if CRC32 doesn't match. */
-  if (dest->crc32 !=
+  if (dest->crc32_le !=
       avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t))) {
     avb_error("CRC32 does not match.\n");
     return false;
@@ -55,22 +53,24 @@ bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
 void avb_ab_data_update_crc_and_byteswap(const AvbABData* src,
                                          AvbABData* dest) {
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_htobe32(
-      avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t)));
+  dest->crc32_le = avb_crc32((const uint8_t*)dest,
+                             sizeof(AvbABData) - sizeof(uint32_t));
 }
 
 void avb_ab_data_init(AvbABData* data) {
   avb_memset(data, '\0', sizeof(AvbABData));
-  avb_memcpy(data->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN);
-  data->version_major = AVB_AB_MAJOR_VERSION;
-  data->version_minor = AVB_AB_MINOR_VERSION;
-  data->slots[0].priority = AVB_AB_MAX_PRIORITY;
-  data->slots[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[0].successful_boot = 0;
-  data->slots[1].priority = AVB_AB_MAX_PRIORITY - 1;
-  data->slots[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[1].successful_boot = 0;
+  data->magic = BOOT_CTRL_MAGIC;
+  data->version_major = BOOT_CTRL_VERSION;
+  data->nb_slot = 2;
+  data->slot_info[0].priority = AVB_AB_MAX_PRIORITY;
+  data->slot_info[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[0].successful_boot = 0;
+  data->slot_info[1].priority = AVB_AB_MAX_PRIORITY - 1;
+  data->slot_info[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[1].successful_boot = 0;
+  avb_memcpy(data->slot_suffix, "_a", 2);
 }
+
 
 /* The AvbABData struct is stored 2048 bytes into the 'misc' partition
  * following the 'struct bootloader_message' field. The struct is
@@ -152,16 +152,11 @@ static void slot_normalize(AvbABSlotData* slot) {
       /* We've exhausted all tries -> unbootable. */
       slot_set_unbootable(slot);
     }
-    if (slot->tries_remaining > 0 && slot->successful_boot) {
-      /* Illegal state - avb_ab_mark_slot_successful() will clear
-       * tries_remaining when setting successful_boot.
-       */
-      slot_set_unbootable(slot);
-    }
   } else {
     slot_set_unbootable(slot);
   }
 }
+
 
 static const char* slot_suffixes[2] = {"_a", "_b"};
 
@@ -184,8 +179,8 @@ static AvbIOResult load_metadata(AvbABOps* ab_ops,
    * unbootable and all unbootable states are represented with
    * (priority=0, tries_remaining=0, successful_boot=0).
    */
-  slot_normalize(&ab_data->slots[0]);
-  slot_normalize(&ab_data->slots[1]);
+  slot_normalize(&ab_data->slot_info[0]);
+  slot_normalize(&ab_data->slot_info[1]);
   return AVB_IO_RESULT_OK;
 }
 
@@ -227,7 +222,7 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
 
   /* Validate all bootable slots. */
   for (n = 0; n < 2; n++) {
-    if (slot_is_bootable(&ab_data.slots[n])) {
+    if (slot_is_bootable(&ab_data.slot_info[n])) {
       AvbSlotVerifyResult verify_result;
       bool set_slot_unbootable = false;
 
@@ -291,21 +286,21 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
                    avb_slot_verify_result_to_string(verify_result),
                    " - setting unbootable.\n",
                    NULL);
-        slot_set_unbootable(&ab_data.slots[n]);
+        slot_set_unbootable(&ab_data.slot_info[n]);
       }
     }
   }
 
-  if (slot_is_bootable(&ab_data.slots[0]) &&
-      slot_is_bootable(&ab_data.slots[1])) {
-    if (ab_data.slots[1].priority > ab_data.slots[0].priority) {
+  if (slot_is_bootable(&ab_data.slot_info[0]) &&
+      slot_is_bootable(&ab_data.slot_info[1])) {
+    if (ab_data.slot_info[1].priority > ab_data.slot_info[0].priority) {
       slot_index_to_boot = 1;
     } else {
       slot_index_to_boot = 0;
     }
-  } else if (slot_is_bootable(&ab_data.slots[0])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[0])) {
     slot_index_to_boot = 0;
-  } else if (slot_is_bootable(&ab_data.slots[1])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[1])) {
     slot_index_to_boot = 1;
   } else {
     /* No bootable slots! */
@@ -370,9 +365,9 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
   }
 
   /* ... and decrement tries remaining, if applicable. */
-  if (!ab_data.slots[slot_index_to_boot].successful_boot &&
-      ab_data.slots[slot_index_to_boot].tries_remaining > 0) {
-    ab_data.slots[slot_index_to_boot].tries_remaining -= 1;
+  if (!ab_data.slot_info[slot_index_to_boot].successful_boot &&
+      ab_data.slot_info[slot_index_to_boot].tries_remaining > 0) {
+    ab_data.slot_info[slot_index_to_boot].tries_remaining -= 1;
   }
 
 out:
@@ -412,11 +407,7 @@ AvbIOResult avb_ab_mark_slot_active(AvbABOps* ab_ops,
   unsigned int other_slot_number;
   AvbIOResult ret;
 
-  //avb_assert(slot_number < 2);
-  if (slot_number >= 2) {
-    ret = AVB_IO_RESULT_ERROR_IO;
-    goto out;
-  }
+  avb_assert(slot_number < 2);
 
   ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
   if (ret != AVB_IO_RESULT_OK) {
@@ -424,14 +415,14 @@ AvbIOResult avb_ab_mark_slot_active(AvbABOps* ab_ops,
   }
 
   /* Make requested slot top priority, unsuccessful, and with max tries. */
-  ab_data.slots[slot_number].priority = AVB_AB_MAX_PRIORITY;
-  ab_data.slots[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  ab_data.slots[slot_number].successful_boot = 0;
+  ab_data.slot_info[slot_number].priority = AVB_AB_MAX_PRIORITY;
+  ab_data.slot_info[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  ab_data.slot_info[slot_number].successful_boot = 0;
 
   /* Ensure other slot doesn't have as high a priority. */
   other_slot_number = 1 - slot_number;
-  if (ab_data.slots[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
-    ab_data.slots[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
+  if (ab_data.slot_info[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
+    ab_data.slot_info[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
   }
 
   ret = AVB_IO_RESULT_OK;
@@ -453,7 +444,7 @@ unsigned int avb_ab_get_active_slot(AvbABOps* ab_ops) {
   }
 
   for (unsigned int i = 0; i < 2; i++) {
-      if (ab_data_orig.slots[i].priority == AVB_AB_MAX_PRIORITY)
+      if (ab_data_orig.slot_info[i].priority == AVB_AB_MAX_PRIORITY)
           return i;
   }
 
@@ -461,23 +452,20 @@ out:
   return 0;
 }
 
+
 AvbIOResult avb_ab_mark_slot_unbootable(AvbABOps* ab_ops,
                                         unsigned int slot_number) {
   AvbABData ab_data, ab_data_orig;
   AvbIOResult ret;
 
-  //avb_assert(slot_number < 2);
-  if (slot_number >= 2) {
-    ret = AVB_IO_RESULT_ERROR_IO;
-    goto out;
-  }
+  avb_assert(slot_number < 2);
 
   ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
   if (ret != AVB_IO_RESULT_OK) {
     goto out;
   }
 
-  slot_set_unbootable(&ab_data.slots[slot_number]);
+  slot_set_unbootable(&ab_data.slot_info[slot_number]);
 
   ret = AVB_IO_RESULT_OK;
 
@@ -500,14 +488,14 @@ AvbIOResult avb_ab_mark_slot_successful(AvbABOps* ab_ops,
     goto out;
   }
 
-  if (!slot_is_bootable(&ab_data.slots[slot_number])) {
+  if (!slot_is_bootable(&ab_data.slot_info[slot_number])) {
     avb_error("Cannot mark unbootable slot as successful.\n");
     ret = AVB_IO_RESULT_OK;
     goto out;
   }
 
-  ab_data.slots[slot_number].tries_remaining = 0;
-  ab_data.slots[slot_number].successful_boot = 1;
+  ab_data.slot_info[slot_number].tries_remaining = 0;
+  ab_data.slot_info[slot_number].successful_boot = 1;
 
   ret = AVB_IO_RESULT_OK;
 

--- a/libavb_ab/avb_ab_ops.h
+++ b/libavb_ab/avb_ab_ops.h
@@ -39,7 +39,7 @@ extern "C" {
 struct AvbABOps;
 typedef struct AvbABOps AvbABOps;
 
-struct AvbABData;
+struct bootloader_control;
 
 /* High-level operations/functions/methods for A/B that are platform
  * dependent.
@@ -59,7 +59,8 @@ struct AvbABOps {
    * Implementations will typically want to use avb_ab_data_read()
    * here to use the 'misc' partition for persistent storage.
    */
-  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops, struct AvbABData* data);
+  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops,
+                                  struct bootloader_control* data);
 
   /* Writes A/B metadata to persistent storage. This will byteswap and
    * update the CRC as needed. Returns AVB_IO_RESULT_OK on success,
@@ -69,7 +70,7 @@ struct AvbABOps {
    * here to use the 'misc' partition for persistent storage.
    */
   AvbIOResult (*write_ab_metadata)(AvbABOps* ab_ops,
-                                   const struct AvbABData* data);
+                                   const struct bootloader_control* data);
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
bootctrl and kernelflinger share some code, such as the
avb releted code. Currently some of the data struct
between bootctrl and kernelflinger have some mismatch.
This will make OTA cannot work properly.

Tracked-On: OAM-100225
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>