### PR TITLE
update bootctrl with kernelflinger

### DIFF
--- a/boot_control_avb.h
+++ b/boot_control_avb.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef BOOT_CONTROL_AVB_H_
+#define BOOT_CONTROL_AVB_H_
+
+//#include <android/hardware/boot/1.1/IBootControl.h>
+#include <hardware/boot_control.h>
+#include <hardware/hardware.h>
+
+typedef struct private_boot_control {
+    boot_control_module_t base;
+    bool (*SetSnapshotMergeStatus)(uint8_t status);
+    uint8_t (*GetSnapshotMergeStatus)(void);
+} private_boot_control_t;
+
+#endif /* BOOT_CONTROL_AVB_H_*/

--- a/libavb_ab/avb_ab_flow.c
+++ b/libavb_ab/avb_ab_flow.c
@@ -26,24 +26,22 @@
 
 bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
   /* Ensure magic is correct. */
-  if (avb_safe_memcmp(src->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN) != 0) {
+  if (src->magic != BOOT_CTRL_MAGIC) {
     avb_error("Magic is incorrect.\n");
     return false;
   }
 
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_be32toh(dest->crc32);
-
   /* Ensure we don't attempt to access any fields if the major version
    * is not supported.
    */
-  if (dest->version_major > AVB_AB_MAJOR_VERSION) {
+  if (dest->version_major > BOOT_CTRL_VERSION) {
     avb_error("No support for given major version.\n");
     return false;
   }
 
   /* Bail if CRC32 doesn't match. */
-  if (dest->crc32 !=
+  if (dest->crc32_le !=
       avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t))) {
     avb_error("CRC32 does not match.\n");
     return false;
@@ -55,22 +53,24 @@ bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
 void avb_ab_data_update_crc_and_byteswap(const AvbABData* src,
                                          AvbABData* dest) {
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_htobe32(
-      avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t)));
+  dest->crc32_le = avb_crc32((const uint8_t*)dest,
+                             sizeof(AvbABData) - sizeof(uint32_t));
 }
 
 void avb_ab_data_init(AvbABData* data) {
   avb_memset(data, '\0', sizeof(AvbABData));
-  avb_memcpy(data->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN);
-  data->version_major = AVB_AB_MAJOR_VERSION;
-  data->version_minor = AVB_AB_MINOR_VERSION;
-  data->slots[0].priority = AVB_AB_MAX_PRIORITY;
-  data->slots[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[0].successful_boot = 0;
-  data->slots[1].priority = AVB_AB_MAX_PRIORITY - 1;
-  data->slots[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[1].successful_boot = 0;
+  data->magic = BOOT_CTRL_MAGIC;
+  data->version_major = BOOT_CTRL_VERSION;
+  data->nb_slot = 2;
+  data->slot_info[0].priority = AVB_AB_MAX_PRIORITY;
+  data->slot_info[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[0].successful_boot = 0;
+  data->slot_info[1].priority = AVB_AB_MAX_PRIORITY - 1;
+  data->slot_info[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[1].successful_boot = 0;
+  avb_memcpy(data->slot_suffix, "_a", 2);
 }
+
 
 /* The AvbABData struct is stored 2048 bytes into the 'misc' partition
  * following the 'struct bootloader_message' field. The struct is
@@ -152,16 +152,11 @@ static void slot_normalize(AvbABSlotData* slot) {
       /* We've exhausted all tries -> unbootable. */
       slot_set_unbootable(slot);
     }
-    if (slot->tries_remaining > 0 && slot->successful_boot) {
-      /* Illegal state - avb_ab_mark_slot_successful() will clear
-       * tries_remaining when setting successful_boot.
-       */
-      slot_set_unbootable(slot);
-    }
   } else {
     slot_set_unbootable(slot);
   }
 }
+
 
 static const char* slot_suffixes[2] = {"_a", "_b"};
 
@@ -184,8 +179,8 @@ static AvbIOResult load_metadata(AvbABOps* ab_ops,
    * unbootable and all unbootable states are represented with
    * (priority=0, tries_remaining=0, successful_boot=0).
    */
-  slot_normalize(&ab_data->slots[0]);
-  slot_normalize(&ab_data->slots[1]);
+  slot_normalize(&ab_data->slot_info[0]);
+  slot_normalize(&ab_data->slot_info[1]);
   return AVB_IO_RESULT_OK;
 }
 
@@ -227,7 +222,7 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
 
   /* Validate all bootable slots. */
   for (n = 0; n < 2; n++) {
-    if (slot_is_bootable(&ab_data.slots[n])) {
+    if (slot_is_bootable(&ab_data.slot_info[n])) {
       AvbSlotVerifyResult verify_result;
       bool set_slot_unbootable = false;
 
@@ -291,21 +286,21 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
                    avb_slot_verify_result_to_string(verify_result),
                    " - setting unbootable.\n",
                    NULL);
-        slot_set_unbootable(&ab_data.slots[n]);
+        slot_set_unbootable(&ab_data.slot_info[n]);
       }
     }
   }
 
-  if (slot_is_bootable(&ab_data.slots[0]) &&
-      slot_is_bootable(&ab_data.slots[1])) {
-    if (ab_data.slots[1].priority > ab_data.slots[0].priority) {
+  if (slot_is_bootable(&ab_data.slot_info[0]) &&
+      slot_is_bootable(&ab_data.slot_info[1])) {
+    if (ab_data.slot_info[1].priority > ab_data.slot_info[0].priority) {
       slot_index_to_boot = 1;
     } else {
       slot_index_to_boot = 0;
     }
-  } else if (slot_is_bootable(&ab_data.slots[0])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[0])) {
     slot_index_to_boot = 0;
-  } else if (slot_is_bootable(&ab_data.slots[1])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[1])) {
     slot_index_to_boot = 1;
   } else {
     /* No bootable slots! */
@@ -370,9 +365,9 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
   }
 
   /* ... and decrement tries remaining, if applicable. */
-  if (!ab_data.slots[slot_index_to_boot].successful_boot &&
-      ab_data.slots[slot_index_to_boot].tries_remaining > 0) {
-    ab_data.slots[slot_index_to_boot].tries_remaining -= 1;
+  if (!ab_data.slot_info[slot_index_to_boot].successful_boot &&
+      ab_data.slot_info[slot_index_to_boot].tries_remaining > 0) {
+    ab_data.slot_info[slot_index_to_boot].tries_remaining -= 1;
   }
 
 out:
@@ -412,11 +407,7 @@ AvbIOResult avb_ab_mark_slot_active(AvbABOps* ab_ops,
   unsigned int other_slot_number;
   AvbIOResult ret;
 
-  //avb_assert(slot_number < 2);
-  if (slot_number >= 2) {
-    ret = AVB_IO_RESULT_ERROR_IO;
-    goto out;
-  }
+  avb_assert(slot_number < 2);
 
   ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
   if (ret != AVB_IO_RESULT_OK) {
@@ -424,14 +415,14 @@ AvbIOResult avb_ab_mark_slot_active(AvbABOps* ab_ops,
   }
 
   /* Make requested slot top priority, unsuccessful, and with max tries. */
-  ab_data.slots[slot_number].priority = AVB_AB_MAX_PRIORITY;
-  ab_data.slots[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  ab_data.slots[slot_number].successful_boot = 0;
+  ab_data.slot_info[slot_number].priority = AVB_AB_MAX_PRIORITY;
+  ab_data.slot_info[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  ab_data.slot_info[slot_number].successful_boot = 0;
 
   /* Ensure other slot doesn't have as high a priority. */
   other_slot_number = 1 - slot_number;
-  if (ab_data.slots[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
-    ab_data.slots[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
+  if (ab_data.slot_info[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
+    ab_data.slot_info[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
   }
 
   ret = AVB_IO_RESULT_OK;
@@ -453,7 +444,7 @@ unsigned int avb_ab_get_active_slot(AvbABOps* ab_ops) {
   }
 
   for (unsigned int i = 0; i < 2; i++) {
-      if (ab_data_orig.slots[i].priority == AVB_AB_MAX_PRIORITY)
+      if (ab_data_orig.slot_info[i].priority == AVB_AB_MAX_PRIORITY)
           return i;
   }
 
@@ -461,23 +452,20 @@ out:
   return 0;
 }
 
+
 AvbIOResult avb_ab_mark_slot_unbootable(AvbABOps* ab_ops,
                                         unsigned int slot_number) {
   AvbABData ab_data, ab_data_orig;
   AvbIOResult ret;
 
-  //avb_assert(slot_number < 2);
-  if (slot_number >= 2) {
-    ret = AVB_IO_RESULT_ERROR_IO;
-    goto out;
-  }
+  avb_assert(slot_number < 2);
 
   ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
   if (ret != AVB_IO_RESULT_OK) {
     goto out;
   }
 
-  slot_set_unbootable(&ab_data.slots[slot_number]);
+  slot_set_unbootable(&ab_data.slot_info[slot_number]);
 
   ret = AVB_IO_RESULT_OK;
 
@@ -486,6 +474,46 @@ out:
     ret = save_metadata_if_changed(ab_ops, &ab_data, &ab_data_orig);
   }
   return ret;
+}
+
+AvbIOResult avb_ab_set_snapshot_merge_status(AvbABOps* ab_ops,
+                                        uint8_t merge_status) {
+  AvbABData ab_data, ab_data_orig;
+  AvbIOResult ret;
+
+  if (merge_status > CANCELLED)
+    merge_status = UNKNOWN;
+
+  ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
+  if (ret != AVB_IO_RESULT_OK) {
+    goto out;
+  }
+
+  ab_data.merge_status = merge_status;
+
+  ret = AVB_IO_RESULT_OK;
+
+out:
+  if (ret == AVB_IO_RESULT_OK) {
+    ret = save_metadata_if_changed(ab_ops, &ab_data, &ab_data_orig);
+  }
+  return ret;
+}
+
+uint8_t avb_ab_get_snapshot_merge_status(AvbABOps* ab_ops) {
+  AvbABData ab_data, ab_data_orig;
+  AvbIOResult ret;
+  uint8_t status = UNKNOWN;
+
+  ret = load_metadata(ab_ops, &ab_data, &ab_data_orig);
+  if (ret != AVB_IO_RESULT_OK) {
+    goto out;
+  }
+
+  status = ab_data.merge_status;
+
+out:
+  return status;
 }
 
 AvbIOResult avb_ab_mark_slot_successful(AvbABOps* ab_ops,
@@ -500,14 +528,14 @@ AvbIOResult avb_ab_mark_slot_successful(AvbABOps* ab_ops,
     goto out;
   }
 
-  if (!slot_is_bootable(&ab_data.slots[slot_number])) {
+  if (!slot_is_bootable(&ab_data.slot_info[slot_number])) {
     avb_error("Cannot mark unbootable slot as successful.\n");
     ret = AVB_IO_RESULT_OK;
     goto out;
   }
 
-  ab_data.slots[slot_number].tries_remaining = 0;
-  ab_data.slots[slot_number].successful_boot = 1;
+  ab_data.slot_info[slot_number].tries_remaining = 0;
+  ab_data.slot_info[slot_number].successful_boot = 1;
 
   ret = AVB_IO_RESULT_OK;
 

--- a/libavb_ab/avb_ab_flow.h
+++ b/libavb_ab/avb_ab_flow.h
@@ -36,69 +36,63 @@
 extern "C" {
 #endif
 
-/* Magic for the A/B struct when serialized. */
-#define AVB_AB_MAGIC "\0AB0"
-#define AVB_AB_MAGIC_LEN 4
-
-/* Versioning for the on-disk A/B metadata - keep in sync with avbtool. */
-#define AVB_AB_MAJOR_VERSION 1
-#define AVB_AB_MINOR_VERSION 0
-
-/* Size of AvbABData struct. */
-#define AVB_AB_DATA_SIZE 32
+#define BOOT_CTRL_MAGIC   0x42414342 /* Bootloader Control AB */
+#define BOOT_CTRL_VERSION 1
 
 /* Maximum values for slot data */
 #define AVB_AB_MAX_PRIORITY 15
 #define AVB_AB_MAX_TRIES_REMAINING 7
 
-/* Struct used for recording per-slot metadata.
+typedef struct slot_metadata {
+    // Slot priority with 15 meaning highest priority, 1 lowest
+    // priority and 0 the slot is unbootable.
+    uint8_t priority : 4;
+    // Number of times left attempting to boot this slot.
+    uint8_t tries_remaining : 3;
+    // 1 if this slot has booted successfully, 0 otherwise.
+    uint8_t successful_boot : 1;
+    // 1 if this slot is corrupted from a dm-verity corruption, 0
+    // otherwise.
+    uint8_t verity_corrupted : 1;
+    // Reserved for further use.
+    uint8_t reserved : 7;
+} __attribute__((packed)) slot_metadata_t;
+
+/* Bootloader Control AB
  *
- * When serialized, data is stored in network byte-order.
+ * This struct can be used to manage A/B metadata. It is designed to
+ * be put in the 'slot_suffix' field of the 'bootloader_message'
+ * structure described above. It is encouraged to use the
+ * 'bootloader_control' structure to store the A/B metadata, but not
+ * mandatory.
  */
-typedef struct AvbABSlotData {
-  /* Slot priority. Valid values range from 0 to AVB_AB_MAX_PRIORITY,
-   * both inclusive with 1 being the lowest and AVB_AB_MAX_PRIORITY
-   * being the highest. The special value 0 is used to indicate the
-   * slot is unbootable.
-   */
-  uint8_t priority;
+typedef struct bootloader_control {
+    // NUL terminated active slot suffix.
+    char slot_suffix[4];
+    // Bootloader Control AB magic number (see BOOT_CTRL_MAGIC).
+    uint32_t magic;
 
-  /* Number of times left attempting to boot this slot ranging from 0
-   * to AVB_AB_MAX_TRIES_REMAINING.
-   */
-  uint8_t tries_remaining;
+    // Version of struct being used (see BOOT_CTRL_VERSION).
+    uint8_t version_major; // version;
+    // Number of slots being managed.
+    uint8_t nb_slot : 3;
+    // Number of times left attempting to boot recovery.
+    uint8_t recovery_tries_remaining : 3;
+    // Status of any pending snapshot merge of dynamic partitions.
+    uint8_t merge_status : 3;
+    // Ensure 4-bytes alignment for slot_info field.
+    uint8_t reserved0[1];
+    // Per-slot information.  Up to 4 slots.
+    struct slot_metadata slot_info[4];
+    // Reserved for further use.
+    uint8_t reserved1[8];
+    // CRC32 of all 28 bytes preceding this field (little endian
+    // format).
+    uint32_t crc32_le;
+} AVB_ATTR_PACKED bootloader_control;
 
-  /* Non-zero if this slot has booted successfully, 0 otherwise. */
-  uint8_t successful_boot;
-
-  /* Reserved for future use. */
-  uint8_t reserved[1];
-} AVB_ATTR_PACKED AvbABSlotData;
-
-/* Struct used for recording A/B metadata.
- *
- * When serialized, data is stored in network byte-order.
- */
-typedef struct AvbABData {
-  /* Magic number used for identification - see AVB_AB_MAGIC. */
-  uint8_t magic[AVB_AB_MAGIC_LEN];
-
-  /* Version of on-disk struct - see AVB_AB_{MAJOR,MINOR}_VERSION. */
-  uint8_t version_major;
-  uint8_t version_minor;
-
-  /* Padding to ensure |slots| field start eight bytes in. */
-  uint8_t reserved1[2];
-
-  /* Per-slot metadata. */
-  AvbABSlotData slots[2];
-
-  /* Reserved for future use. */
-  uint8_t reserved2[12];
-
-  /* CRC32 of all 28 bytes preceding this field. */
-  uint32_t crc32;
-} AVB_ATTR_PACKED AvbABData;
+typedef struct slot_metadata AvbABSlotData;
+typedef struct bootloader_control AvbABData;
 
 /* Copies |src| to |dest|, byte-swapping fields in the
  * process. Returns false if the data is invalid (e.g. wrong magic,
@@ -143,6 +137,14 @@ typedef enum {
   AVB_AB_FLOW_RESULT_ERROR_NO_BOOTABLE_SLOTS,
   AVB_AB_FLOW_RESULT_ERROR_INVALID_ARGUMENT
 } AvbABFlowResult;
+
+typedef enum {
+  NONE = 0,
+  UNKNOWN,
+  SNAPSHOTTED,
+  MERGING,
+  CANCELLED,
+} SnapMergeStatus;
 
 /* Get a textual representation of |result|. */
 const char* avb_ab_flow_result_to_string(AvbABFlowResult result);
@@ -260,6 +262,20 @@ AvbIOResult avb_ab_mark_slot_unbootable(AvbABOps* ab_ops,
  */
 AvbIOResult avb_ab_mark_slot_successful(AvbABOps* ab_ops,
                                         unsigned int slot_number);
+
+/* Set the snapshot merge status of virtual a/b OTA update.
+ * true on success, false on failure.
+ *
+ * This function is typically used by the virtual a/b ota update
+ */
+AvbIOResult avb_ab_set_snapshot_merge_status(AvbABOps* ab_ops,
+                                        uint8_t merge_status);
+
+/* Get the snapshot merge status of virtual a/b OTA update.
+ *
+ * This function is typically used by the virtual a/b ota update
+ */
+uint8_t avb_ab_get_snapshot_merge_status(AvbABOps* ab_ops);
 
 #ifdef __cplusplus
 }

--- a/libavb_ab/avb_ab_ops.h
+++ b/libavb_ab/avb_ab_ops.h
@@ -39,7 +39,7 @@ extern "C" {
 struct AvbABOps;
 typedef struct AvbABOps AvbABOps;
 
-struct AvbABData;
+struct bootloader_control;
 
 /* High-level operations/functions/methods for A/B that are platform
  * dependent.
@@ -59,7 +59,8 @@ struct AvbABOps {
    * Implementations will typically want to use avb_ab_data_read()
    * here to use the 'misc' partition for persistent storage.
    */
-  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops, struct AvbABData* data);
+  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops,
+                                  struct bootloader_control* data);
 
   /* Writes A/B metadata to persistent storage. This will byteswap and
    * update the CRC as needed. Returns AVB_IO_RESULT_OK on success,
@@ -69,7 +70,7 @@ struct AvbABOps {
    * here to use the 'misc' partition for persistent storage.
    */
   AvbIOResult (*write_ab_metadata)(AvbABOps* ab_ops,
-                                   const struct AvbABData* data);
+                                   const struct bootloader_control* data);
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently there are some mismatches between bootctrl
and kernelflinger, need to sync bootctrl with kernelflinger.

Tracked-On: OAM-100724
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>